### PR TITLE
Revise IdCollection to PrimaryKeyCollection

### DIFF
--- a/src/core/IHasId.ts
+++ b/src/core/IHasId.ts
@@ -1,3 +1,0 @@
-export interface IHasId<T> {
-  id: T;
-}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,8 @@
-export { IdCollection } from './collections/IdCollection';
+export { PrimaryKeyCollection } from './collections/PrimaryKeyCollection';
 export { IndexedCollectionBase } from './collections/IndexedCollectionBase';
 export { CollectionViewBase } from './collections/CollectionViewBase';
 
 export { Optional, Nullable } from './core/Optional';
-export { IHasId } from './core/IHasId';
 export { ICollectionOption } from './core/ICollectionOption';
 export { defaultCollectionOption } from './core/defaultCollectionOption';
 export { ICollectionViewOption } from './core/ICollectionViewOption';

--- a/test/PrimaryKeyCollection.test.ts
+++ b/test/PrimaryKeyCollection.test.ts
@@ -1,0 +1,45 @@
+import { IndexedCollectionBase, PrimaryKeyCollection } from '../src';
+import { ICar, newTeslaModelX } from './testData';
+
+class SimpleCarCollection extends IndexedCollectionBase<ICar> {
+  constructor() {
+    super();
+  }
+}
+
+class PrimaryKeyCarCollection extends PrimaryKeyCollection<ICar> {
+  constructor() {
+    super(car => car.id);
+  }
+}
+
+describe('Prevent duplicate addition', () => {
+  let simpleCollection: SimpleCarCollection;
+  let primaryKeyCollection: PrimaryKeyCarCollection;
+
+  beforeEach(() => {
+    simpleCollection = new SimpleCarCollection();
+    primaryKeyCollection = new PrimaryKeyCarCollection();
+
+    const clonedCar = Object.assign({}, newTeslaModelX);
+
+    simpleCollection.add(newTeslaModelX);
+    simpleCollection.add(newTeslaModelX);
+    // clonedCar can be added to the simpleCollection because it is a different object instance
+    simpleCollection.add(clonedCar);
+
+    primaryKeyCollection.add(newTeslaModelX);
+    primaryKeyCollection.add(newTeslaModelX);
+
+    // clonedCar should not be added to pkCollection because it has the same primary key
+    primaryKeyCollection.add(clonedCar);
+  });
+
+  it('simpleCollection should have two cars', () => {
+    expect(simpleCollection.count).toEqual(2);
+  });
+
+  it('primaryKey should have one cars', () => {
+    expect(primaryKeyCollection.count).toEqual(1);
+  });
+});


### PR DESCRIPTION
This pull request adds PrimaryKeyCollection, which allows duplicates to be checked via its primary key value