### PR TITLE
Add InternalList and InternalSetList data structure (1/n)

### DIFF
--- a/src/core/internals/IInternalList.ts
+++ b/src/core/internals/IInternalList.ts
@@ -1,0 +1,24 @@
+export interface IInternalList<T> {
+  /**
+   * Add item to list regardless of existence of such item
+   * @param item
+   */
+  add(item: T): void;
+
+  /**
+   * Remove the first instance item to list regardless of existence of such item
+   * @param item
+   */
+  remove(item: T): void;
+
+  /**
+   * Whether the specified item exists in the list
+   * @param item
+   */
+  exists(item: T): boolean;
+
+  /**
+   * Signal the list has
+   */
+  invalidate(): void;
+}

--- a/src/core/internals/InternalList.ts
+++ b/src/core/internals/InternalList.ts
@@ -1,0 +1,44 @@
+import { IInternalList } from './IInternalList';
+
+/**
+ * A simple list that outputs a new array of the list if
+ * the based array has been modified
+ *
+ * This is an unsupported internal class not meant to be used
+ * beyond internal usage
+ */
+export class InternalList<T> implements IInternalList<T> {
+  private _isSynced: boolean = false;
+  private _output: T[] = [];
+  constructor(public readonly source: T[]) {}
+
+  invalidate() {
+    this._isSynced = false;
+  }
+
+  get output(): readonly T[] {
+    if (!this._isSynced) {
+      this._isSynced = true;
+      this._output = this.source.concat();
+    }
+
+    return this._output;
+  }
+
+  exists(item: T): boolean {
+    return this.source.includes(item);
+  }
+
+  add(item: T): void {
+    this.source.push(item);
+    this.invalidate();
+  }
+
+  remove(item: T): void {
+    const index: number = this.source.findIndex(listItem => listItem === item);
+    if (index >= 0) {
+      this.source.splice(index, 1);
+      this.invalidate();
+    }
+  }
+}

--- a/src/core/internals/InternalSetList.ts
+++ b/src/core/internals/InternalSetList.ts
@@ -1,0 +1,42 @@
+import { IInternalList } from './IInternalList';
+
+/**
+ * An internal data structure that's based on a set
+ * and output a new array if the set has changed
+ * Change of set is notified through invalidate() method
+ *
+ * This is an unsupported internal class not meant to be used
+ * beyond internal usage
+ */
+export class InternalSetList<T> implements IInternalList<T> {
+  private _isSynced: boolean = false;
+  private _output: T[] = [];
+
+  constructor(public readonly source: Set<T>) {}
+  invalidate(): void {
+    this._isSynced = false;
+  }
+
+  get output(): readonly T[] {
+    if (!this._isSynced) {
+      this._isSynced = true;
+      this._output = Array.from(this.source);
+    }
+
+    return this._output;
+  }
+
+  add(item: T): void {
+    this.source.add(item);
+    this.invalidate();
+  }
+
+  exists(item: T): boolean {
+    return this.source.has(item);
+  }
+
+  remove(item: T): void {
+    this.source.delete(item);
+    this.invalidate();
+  }
+}

--- a/test/internals/InternalList.test.ts
+++ b/test/internals/InternalList.test.ts
@@ -1,0 +1,88 @@
+import { InternalList } from '../../src/core/internals/InternalList';
+
+describe('invalidation test', () => {
+  let outputBefore: readonly number[];
+  let list: InternalList<number>;
+
+  beforeEach(() => {
+    const source = [1, 6, 7];
+    list = new InternalList<number>(source);
+    outputBefore = list.output;
+  });
+
+  describe('encapsulated mutation', () => {
+    describe('add', () => {
+      beforeEach(() => {
+        list.add(8);
+      });
+
+      test('source should consist the new element', () => {
+        expect(list.source).toContain(8);
+      });
+
+      test('output should consist the new element', () => {
+        expect(list.output).toContain(8);
+      });
+
+      test('output should return a different instance of array', () => {
+        expect(list.output).not.toBe(outputBefore);
+      });
+    });
+
+    describe('remove', () => {
+      beforeEach(() => {
+        list.remove(6);
+      });
+
+      test('source should consist the new element', () => {
+        expect(list.source).not.toContain(6);
+      });
+
+      test('output should consist the new element', () => {
+        expect(list.output).not.toContain(8);
+      });
+
+      test('output should return a different instance of array', () => {
+        expect(list.output).not.toBe(outputBefore);
+      });
+    });
+  });
+
+  describe('direct source mutation - invalidate should generate a new list after changes', () => {
+    beforeEach(() => {
+      list.source.push(8);
+      list.invalidate();
+    });
+
+    test('source should consist the new element', () => {
+      expect(list.source).toContain(8);
+    });
+
+    test('output should consist the new element', () => {
+      expect(list.output).toContain(8);
+    });
+
+    test('output should return a different instance of array', () => {
+      expect(list.output).not.toBe(outputBefore);
+    });
+  });
+
+  describe('direct source mutation - forgetting to invalidate', () => {
+    beforeEach(() => {
+      list.source.push(8);
+      // list.invalidate();
+    });
+
+    test('source should consist the new element', () => {
+      expect(list.source).toContain(8);
+    });
+
+    test('output should not the new element', () => {
+      expect(list.output).not.toContain(8);
+    });
+
+    test('output should return the same as before', () => {
+      expect(list.output).toBe(outputBefore);
+    });
+  });
+});

--- a/test/internals/InternalSetList.test.ts
+++ b/test/internals/InternalSetList.test.ts
@@ -1,0 +1,88 @@
+import { InternalSetList } from '../../src/core/internals/InternalSetList';
+
+describe('invalidation test', () => {
+  let outputBefore: readonly number[];
+  let list: InternalSetList<number>;
+
+  beforeEach(() => {
+    const source = new Set([1, 6, 7]);
+    list = new InternalSetList<number>(source);
+    outputBefore = list.output;
+  });
+
+  describe('encapsulated mutation', () => {
+    describe('add', () => {
+      beforeEach(() => {
+        list.add(8);
+      });
+
+      test('source should consist the new element', () => {
+        expect(list.source).toContain(8);
+      });
+
+      test('output should consist the new element', () => {
+        expect(list.output).toContain(8);
+      });
+
+      test('output should return a different instance of array', () => {
+        expect(list.output).not.toBe(outputBefore);
+      });
+    });
+
+    describe('remove', () => {
+      beforeEach(() => {
+        list.remove(6);
+      });
+
+      test('source should consist the new element', () => {
+        expect(list.source).not.toContain(6);
+      });
+
+      test('output should consist the new element', () => {
+        expect(list.output).not.toContain(8);
+      });
+
+      test('output should return a different instance of array', () => {
+        expect(list.output).not.toBe(outputBefore);
+      });
+    });
+  });
+
+  describe('direct source mutation - invalidate should generate a new list after changes', () => {
+    beforeEach(() => {
+      list.source.add(8);
+      list.invalidate();
+    });
+
+    test('source should consist the new element', () => {
+      expect(list.source).toContain(8);
+    });
+
+    test('output should consist the new element', () => {
+      expect(list.output).toContain(8);
+    });
+
+    test('output should return a different instance of array', () => {
+      expect(list.output).not.toBe(outputBefore);
+    });
+  });
+
+  describe('direct source mutation - forgetting to invalidate', () => {
+    beforeEach(() => {
+      list.source.add(8);
+      // list.invalidate();
+    });
+
+    test('source should consist the new element', () => {
+      expect(list.source).toContain(8);
+    });
+
+    test('output should not the new element', () => {
+      expect(list.output).not.toContain(8);
+    });
+
+    test('output should return the same as before', () => {
+      expect(list.output).toBe(outputBefore);
+    });
+  });
+});


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #17
* #16
* #15
* #14
* __->__ #13

In IndexBase and IndexedCollectionBase, there are repeating code on deciding whether Set or Array should be used for record the data.  InternalList and InternalSetList are created to encapsulate the repeating code, with also benefits to return a new output only if the underlying data has been changed and invalidated.