### PR TITLE
fix: PrimaryKeyCollection not include idIndex when buildIndex is called

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,5 +5,6 @@ module.exports = {
   collectCoverage: true,
   verbose: true,
   coverageReporters: ['cobertura', 'html', 'lcov'],
+  coveragePathIgnorePatterns: ['index.ts$'],
   testTimeout: 500,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "indexed-collection",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "A zero-dependency library of classes that make filtering, sorting and observing changes to arrays easier and more efficient.",
   "license": "MIT",
   "keywords": [

--- a/src/collections/PrimaryKeyCollection.ts
+++ b/src/collections/PrimaryKeyCollection.ts
@@ -28,6 +28,21 @@ export class PrimaryKeyCollection<
     }
   }
 
+  protected override buildIndexes(
+    indexes: readonly IIndex<T>[],
+    autoReindex?: boolean
+  ): void {
+    const combinedIndex: IIndex<T>[] = [];
+    if (this.idIndex != null) {
+      // this.idIndex can be null during instantiation
+      combinedIndex.push(this.idIndex);
+    }
+    if (indexes != null && indexes.length > 0) {
+      combinedIndex.push(...indexes);
+    }
+    super.buildIndexes(combinedIndex, autoReindex);
+  }
+
   exists(item: T): boolean {
     const key = this.primaryKeyExtract(item);
     return Boolean(this.byPrimaryKey(key));

--- a/test/CollectionSignal.test.ts
+++ b/test/CollectionSignal.test.ts
@@ -8,6 +8,7 @@ import {
   newTeslaModel3,
   newTeslaModelX,
   usedChevyCamero,
+  usedTeslaModel3,
 } from './shared/data';
 
 describe('Collection signal tests', () => {
@@ -114,6 +115,24 @@ describe('Collection signal tests', () => {
 
     test('Should trigger no update signal in view', () => {
       expect(updateViewSignal).toHaveBeenCalledTimes(0);
+    });
+
+    describe('When unregister add signal', () => {
+      beforeEach(() => {
+        changeViewSignal.mockClear();
+        changeSignal.mockClear();
+        carCollection.unregisterObserver(changeSignal);
+        usedCarCollection.unregisterObserver(changeViewSignal);
+        carCollection.add(usedTeslaModel3);
+      });
+
+      test("should not trigger collection's change signal", () => {
+        expect(changeSignal).toHaveBeenCalledTimes(0);
+      });
+
+      test("should not trigger view's change signal", () => {
+        expect(changeViewSignal).toHaveBeenCalledTimes(0);
+      });
     });
   });
 });

--- a/test/collectionview.test.ts
+++ b/test/collectionview.test.ts
@@ -1,9 +1,11 @@
+import { CollectionViewBase } from '../src';
 import {
   CarCollection,
   UsedCarCollectionView,
   UsedGasCarCollectionView,
 } from './shared/collections';
 import {
+  ICar,
   allCars,
   usedChevyCamero,
   usedChevyEquinox,
@@ -11,17 +13,34 @@ import {
   usedTeslaModelX,
 } from './shared/data';
 
+/**
+ * View with out any filter or sort set
+ */
+class DefaultView extends CollectionViewBase<ICar, CarCollection> {
+  constructor(source: CarCollection) {
+    super(source);
+  }
+}
+
 describe('collection view tests', () => {
   let cars: CarCollection;
   let usedCars: UsedCarCollectionView;
   let usedGasCars: UsedGasCarCollectionView;
+  let defaultView: DefaultView;
 
   beforeEach(() => {
     cars = new CarCollection();
     cars.addRange(allCars);
 
+    defaultView = new DefaultView(cars);
     usedCars = new UsedCarCollectionView(cars);
     usedGasCars = new UsedGasCarCollectionView(usedCars);
+  });
+
+  describe('DefaultView', () => {
+    it('defaultView has same number of items as collection', () => {
+      expect(defaultView.count).toEqual(cars.count);
+    });
   });
 
   // Tests against index which is only based on one value
@@ -68,6 +87,14 @@ describe('collection view tests', () => {
       expect(new Set(usedCars.byMake('Tesla'))).toEqual(
         new Set([usedTeslaModelX])
       );
+    });
+
+    it('exist should return false with the removed car', () => {
+      expect(usedCars.exists(usedTeslaModel3)).toEqual(false);
+    });
+
+    it('exist should return true with cars not removed', () => {
+      expect(usedCars.exists(usedTeslaModelX)).toEqual(true);
     });
   });
 });


### PR DESCRIPTION
fix: PrimaryKeyCollection not include idIndex when buildIndex is called


Summary:

Test Plan:
