### PR TITLE
Fix moveAfter logic

### DIFF
--- a/src/core/internals/InternalList.ts
+++ b/src/core/internals/InternalList.ts
@@ -79,9 +79,11 @@ export class InternalList<T> implements IInternalList<T> {
     const afterIndex: number = this.source.findIndex(
       (listItem) => listItem === after
     );
+
     if (itemIndex >= 0 && afterIndex >= 0) {
       this.source.splice(itemIndex, 1);
-      this.source.splice(afterIndex, 0, item);
+      const targetIndex = itemIndex < afterIndex ? afterIndex : afterIndex + 1;
+      this.source.splice(targetIndex, 0, item);
       this.invalidate();
     }
   }

--- a/test/internals/InternalList.test.ts
+++ b/test/internals/InternalList.test.ts
@@ -67,6 +67,16 @@ describe('invalidation test', () => {
         expect(list.source).toEqual([6, 1, 7]);
       });
     });
+
+    describe('moveAfter when item is after the reference', () => {
+      beforeEach(() => {
+        list.moveAfter(7, 1);
+      });
+
+      test('source reorder the number according to the move', () => {
+        expect(list.source).toEqual([1, 7, 6]);
+      });
+    });
   });
 
   describe('direct source mutation - invalidate should generate a new list after changes', () => {


### PR DESCRIPTION
## Summary
- fix `moveAfter` logic to correctly reposition items
- test moving items after elements in different positions

## Testing
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_683b51012cf8832b805e788235b7dc6c