### PR TITLE
Fix README snippet imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ The community want to keep statistics by gender initially for everybody. Let's b
 that indexes on gender
 
 ```JavaScript
-import { IndexedCollectionBase, CollectionIndex, CollectionViewBase } from 'indexed-colection';
+import { IndexedCollectionBase, CollectionIndex, CollectionViewBase } from 'indexed-collection';
 
 class PeopleCollection extends IndexedCollectionBase {
-  construtor() {
+  constructor() {
     super();
     this.genderIndex = new CollectionIndex([(person) => person.gender]);
     this.buildIndexes([


### PR DESCRIPTION
## Summary
- correct the library import path in README example
- fix `constructor` typo

## Testing
- `npm test` *(fails: dts not found)*

------
https://chatgpt.com/codex/tasks/task_b_683b5c5b62c8832bb8d5bc9bd9fe329b