### PR TITLE
Fix filter test for used gas cars by make

### DIFF
--- a/test/collectionview.test.ts
+++ b/test/collectionview.test.ts
@@ -56,7 +56,7 @@ describe('collection view tests', () => {
     });
 
     it('usedGasCars.byMake(Chevy) should return all used Chevy', () => {
-      expect(new Set(usedCars.byMake('Chevy'))).toEqual(
+      expect(new Set(usedGasCars.byMake('Chevy'))).toEqual(
         new Set([usedChevyCamero, usedChevyEquinox])
       );
     });


### PR DESCRIPTION
## Summary
- correct the `usedGasCars.byMake('Chevy')` test to use the correct collection

## Testing
- `npm test` *(fails: `dts` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683b5c621604832b8bea3d3aece9729e