### PR TITLE
Use rolldown for packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,15 @@
   },
   "homepage": "https://github.com/tangentlin/indexed-collection#readme",
   "main": "dist/index.js",
-  "typings": "dist/index.d.ts",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "dist",
     "src"
@@ -34,11 +42,11 @@
   },
   "scripts": {
     "analyze": "size-limit --why",
-    "build": "dts build",
+    "build": "rolldown -c",
     "lint": "exit 0",
-    "prepare": "dts build",
+    "prepare": "rolldown -c",
     "size": "size-limit",
-    "start": "dts watch",
+    "start": "rolldown -w",
     "test": "dts test",
     "prettier": "prettier --write -c src test"
   },
@@ -53,20 +61,20 @@
     "singleQuote": true,
     "trailingComma": "es5"
   },
-  "module": "dist/indexed-collection.esm.js",
   "size-limit": [
     {
-      "path": "dist/indexed-collection.cjs.production.min.js",
+      "path": "dist/index.js",
       "limit": "10 KB"
     },
     {
-      "path": "dist/indexed-collection.esm.js",
+      "path": "dist/index.mjs",
       "limit": "10 KB"
     }
   ],
   "devDependencies": {
     "@size-limit/preset-small-lib": "^11.0.2",
     "dts-cli": "^2.0.4",
+    "rolldown": "^0.3.0",
     "size-limit": "^11.0.2",
     "tslib": "^2.6.2",
     "typescript": "^5.3.3"

--- a/rolldown.config.ts
+++ b/rolldown.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'rolldown';
+
+export default defineConfig({
+  input: './src/index.ts',
+  format: ['cjs', 'esm'],
+  dts: true,
+  outDir: 'dist',
+});


### PR DESCRIPTION
## Summary
- use rolldown as the package bundler
- expose both CommonJS and ESM builds via package exports

## Testing
- `yarn test` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_683b5c4ad8b8832b86a2f78c1eb8a42f