### PR TITLE
Convert CollectionNature enum to union type

### DIFF
--- a/src/collections/IndexedCollectionBase.ts
+++ b/src/collections/IndexedCollectionBase.ts
@@ -1,6 +1,6 @@
 import { CollectionNature } from '../core/CollectionNature';
-import { ICollectionChangeDetail } from '../core/ICollectionChangeDetail';
-import { ICollectionOption } from '../core/ICollectionOption';
+import { type ICollectionChangeDetail } from '../core/ICollectionChangeDetail';
+import { type ICollectionOption } from '../core/ICollectionOption';
 import { IIndex } from '../core/IIndex';
 import { IMutableCollection } from '../core/IMutableCollection';
 import { IReadonlyCollection } from '../core/IReadonlyCollection';

--- a/src/core/CollectionNature.ts
+++ b/src/core/CollectionNature.ts
@@ -1,11 +1,13 @@
-export enum CollectionNature {
+export const CollectionNature = {
   /**
    * The items in the collection should always be unique, and order does not matter
    * This option is always performant
    */
-  Set = 'set',
+  Set: 'set',
   /**
    * The items in the collection should always preserve the order it is entered in the collection
    */
-  Array = 'array',
-}
+  Array: 'array',
+} as const;
+
+export type CollectionNature = (typeof CollectionNature)[keyof typeof CollectionNature];

--- a/src/core/ICollectionOption.ts
+++ b/src/core/ICollectionOption.ts
@@ -1,4 +1,4 @@
-import { CollectionNature } from './CollectionNature';
+import { type CollectionNature } from './CollectionNature';
 
 export interface ICollectionOption {
   nature: CollectionNature;

--- a/src/core/defaultCollectionOption.ts
+++ b/src/core/defaultCollectionOption.ts
@@ -1,5 +1,5 @@
 import { CollectionNature } from './CollectionNature';
-import { ICollectionOption } from './ICollectionOption';
+import { type ICollectionOption } from './ICollectionOption';
 
 export const defaultCollectionOption: Readonly<ICollectionOption> = Object.freeze({
   nature: CollectionNature.Set,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,4 +1,5 @@
 export { CollectionNature } from './CollectionNature';
+export { type CollectionNature } from './CollectionNature';
 export { type ICollectionOption } from './ICollectionOption';
 export { type ICollectionViewOption } from './ICollectionViewOption';
 export { type IMutableCollection } from './IMutableCollection';

--- a/src/indexes/IndexBase.ts
+++ b/src/indexes/IndexBase.ts
@@ -1,5 +1,5 @@
 import { CollectionNature } from '../core/CollectionNature';
-import { ICollectionOption } from '../core/ICollectionOption';
+import { type ICollectionOption } from '../core/ICollectionOption';
 import { KeyExtract } from '../core/KeyExtract';
 import { defaultCollectionOption } from '../core/defaultCollectionOption';
 import { IInternalList } from '../core/internals/IInternalList';


### PR DESCRIPTION
## Summary
- refactor `CollectionNature` enum into a const object plus union type
- adjust imports that rely on `CollectionNature`

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_b_683bad62fc54832ba8c35090f7fbc2c7