### PR TITLE
Refactor constructor APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,10 @@ need to be provided in the constructor. For example
 // Assuming each IPerson is identified by a unique SSN which is a number
 class PeopleCollection extends PrimaryKeyCollection<IPerson, number> {
   constructor(initialValues?: readonly IPerson[]) {
-    super((person: IPerson) => person.ssn);
+    super({
+      primaryKeyExtract: (person: IPerson) => person.ssn,
+      initialValues,
+    });
 
     // Additional indexes similar to IndexedCollectionBased example above
   }

--- a/src/collections/IndexedCollectionBase.ts
+++ b/src/collections/IndexedCollectionBase.ts
@@ -16,6 +16,12 @@ import { SignalObserver } from '../signals/SignalObserver';
 
 import { mergeCollectionChangeDetail } from './util';
 
+export interface IndexedCollectionOptions<T> {
+  initialValues?: readonly T[];
+  indexes?: readonly IIndex<T>[];
+  option?: Partial<ICollectionOption>;
+}
+
 export abstract class IndexedCollectionBase<T> extends SignalObserver implements IMutableCollection<T> {
   private _allItemList: IInternalList<T> = new InternalSetList<T>(new Set());
 
@@ -27,14 +33,11 @@ export abstract class IndexedCollectionBase<T> extends SignalObserver implements
 
   public readonly option: Readonly<ICollectionOption>;
 
-  protected constructor(
-    initialValues?: readonly T[],
-    additionalIndexes: ReadonlyArray<IIndex<T>> = [],
-    option: Partial<ICollectionOption> = defaultCollectionOption
-  ) {
+  protected constructor(options: IndexedCollectionOptions<T> = {}) {
     super();
+    const { initialValues, indexes = [], option = defaultCollectionOption } = options;
     this.option = Object.assign({}, defaultCollectionOption, option);
-    this.buildIndexes(additionalIndexes);
+    this.buildIndexes(indexes);
     if (this.option.nature === CollectionNature.Set) {
       this._allItemList = new InternalSetList<T>(new Set());
     } else {

--- a/src/collections/PrimaryKeyCollection.ts
+++ b/src/collections/PrimaryKeyCollection.ts
@@ -1,28 +1,32 @@
-import { ICollectionOption } from '../core/ICollectionOption';
 import { IIndex } from '../core/IIndex';
 import { SingleKeyExtract } from '../core/KeyExtract';
 import { Optional } from '../core/Optional';
-import { defaultCollectionOption } from '../core/defaultCollectionOption';
 import { CollectionIndex } from '../indexes/CollectionIndex';
 
-import { IndexedCollectionBase } from './IndexedCollectionBase';
+import {
+  IndexedCollectionBase,
+  type IndexedCollectionOptions,
+} from './IndexedCollectionBase';
 
 /**
  * A collection where every item contains a unique identifier key (aka primary key)
  */
+export interface PrimaryKeyCollectionOptions<T, IdT>
+  extends IndexedCollectionOptions<T> {
+  primaryKeyExtract: SingleKeyExtract<T, IdT>;
+}
+
 export class PrimaryKeyCollection<T, IdT = string> extends IndexedCollectionBase<T> {
   protected readonly idIndex: CollectionIndex<T, [IdT]>;
-  constructor(
-    public readonly primaryKeyExtract: SingleKeyExtract<T, IdT>,
-    initialValues?: readonly T[],
-    additionalIndexes: ReadonlyArray<IIndex<T>> = [],
-    option: Readonly<ICollectionOption> = defaultCollectionOption
-  ) {
-    super(undefined, undefined, option);
-    this.idIndex = new CollectionIndex<T, [IdT]>([primaryKeyExtract]);
-    this.buildIndexes([this.idIndex, ...additionalIndexes]);
-    if (initialValues) {
-      this.addRange(initialValues);
+  public readonly primaryKeyExtract: SingleKeyExtract<T, IdT>;
+  constructor(options: PrimaryKeyCollectionOptions<T, IdT>) {
+    const { option } = options;
+    super({ option });
+    this.primaryKeyExtract = options.primaryKeyExtract;
+    this.idIndex = new CollectionIndex<T, [IdT]>([this.primaryKeyExtract]);
+    this.buildIndexes(options.indexes ?? []);
+    if (options.initialValues) {
+      this.addRange(options.initialValues);
     }
   }
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,5 +1,4 @@
 export { CollectionNature } from './CollectionNature';
-export { type CollectionNature } from './CollectionNature';
 export { type ICollectionOption } from './ICollectionOption';
 export { type ICollectionViewOption } from './ICollectionViewOption';
 export { type IMutableCollection } from './IMutableCollection';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,13 @@
 export * from './builders';
 export { CollectionViewBase } from './collections/CollectionViewBase';
-export { IndexedCollectionBase } from './collections/IndexedCollectionBase';
-export { PrimaryKeyCollection } from './collections/PrimaryKeyCollection';
+export {
+  IndexedCollectionBase,
+  type IndexedCollectionOptions,
+} from './collections/IndexedCollectionBase';
+export {
+  PrimaryKeyCollection,
+  type PrimaryKeyCollectionOptions,
+} from './collections/PrimaryKeyCollection';
 export * from './core';
 export { CollectionIndex } from './indexes/CollectionIndex';
 export { IndexBase } from './indexes/IndexBase';

--- a/test/PrimaryKeyCollection.test.ts
+++ b/test/PrimaryKeyCollection.test.ts
@@ -4,13 +4,13 @@ import { ICar, newTeslaModelX } from './shared/data';
 
 class SimpleCarCollection extends IndexedCollectionBase<ICar> {
   constructor(initialValues?: readonly ICar[]) {
-    super(initialValues);
+    super({ initialValues });
   }
 }
 
 class PrimaryKeyCarCollection extends PrimaryKeyCollection<ICar> {
   constructor(initialValues?: readonly ICar[]) {
-    super((car) => car.id, initialValues);
+    super({ primaryKeyExtract: (car) => car.id, initialValues });
   }
 }
 

--- a/test/shared/collections.ts
+++ b/test/shared/collections.ts
@@ -24,7 +24,7 @@ export class CarCollection extends IndexedCollectionBase<ICar> {
   >;
 
   constructor(initialValues?: readonly ICar[], option?: ICollectionOption) {
-    super(initialValues, undefined, option);
+    super({ initialValues, option });
     this.byMakeIndex = getByMakeIndex(option);
     this.byIsNewIndex = getByIsNewIndex(option);
     this.byPriceRangeIndex = getByPriceRangeIndex(option);


### PR DESCRIPTION
## Summary
- refactor `IndexedCollectionBase` and `PrimaryKeyCollection` to accept option objects
- expose new option interfaces in `index.ts`
- update tests and docs for new constructor API
- fix duplicate export in `core/index.ts`

## Testing
- `npm run check:type`
- `npm test` *(fails: vitest not found)*
- `npm run check:lint` *(fails: cannot find @eslint/js)*
- `npm run check:style` *(fails: cannot find prettier-plugin-sort-imports)*

------
https://chatgpt.com/codex/tasks/task_b_683bad4daed8832b98ca574f9613ab58