### PR TITLE
refactor: Improve clarity of IndexBase API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ typings/
 # IDE
 *.iml
 .idea/
+
+# Node compile cache
+node-compile-cache/

--- a/src/collections/IndexedCollectionBase.ts
+++ b/src/collections/IndexedCollectionBase.ts
@@ -126,7 +126,7 @@ export abstract class IndexedCollectionBase<T> extends SignalObserver implements
     this._allItemList.remove(item);
 
     for (const index of this.indexes) {
-      index.unIndex(item);
+      index.unindex(item);
     }
     this.notifyChange({
       removed: [item],
@@ -140,7 +140,7 @@ export abstract class IndexedCollectionBase<T> extends SignalObserver implements
     }
 
     for (const index of this.indexes) {
-      index.unIndex(oldItem);
+      index.unindex(oldItem);
     }
 
     this._allItemList.update(newItem, oldItem);

--- a/src/core/IIndex.ts
+++ b/src/core/IIndex.ts
@@ -11,7 +11,7 @@ export interface IIndex<T> {
    * @param item
    * @return true if the item has been removed to the index successfully.
    */
-  unIndex(item: T): boolean;
+  unindex(item: T): boolean;
 
   reset(): void;
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,5 +1,5 @@
 export { CollectionNature } from './CollectionNature';
-export { type CollectionNature } from './CollectionNature';
+export type { CollectionNature as CollectionNatureType } from './CollectionNature';
 export { type ICollectionOption } from './ICollectionOption';
 export { type ICollectionViewOption } from './ICollectionViewOption';
 export { type IMutableCollection } from './IMutableCollection';

--- a/src/indexes/CollectionIndex.ts
+++ b/src/indexes/CollectionIndex.ts
@@ -16,6 +16,6 @@ export class CollectionIndex<T, KeysT extends KeyTypeArray> extends IndexBase<T>
   }
 
   public getValue(...keys: KeysT): readonly T[] {
-    return super.getValueInternal(keys);
+    return super.getValuesByKey(keys);
   }
 }


### PR DESCRIPTION
## Summary
- ignore node-compile-cache artifacts
- rename IndexBase fields and methods for clearer naming
- rename interface methods accordingly
- adjust re-exports and usage after renaming

## Testing
- `npm run test:ci`
- `npm run check:type`


------
https://chatgpt.com/codex/tasks/task_b_6870fbd69290832bba0eae3a38ce8bc1