### PR TITLE
perf: Improve index lookup mutations and unnecessary list invalidation

### DIFF
--- a/src/core/internals/InternalSetList.ts
+++ b/src/core/internals/InternalSetList.ts
@@ -31,8 +31,11 @@ export class InternalSetList<T> implements IInternalList<T> {
   }
 
   add(item: T): void {
+    const sizeBefore = this.source.size;
     this.source.add(item);
-    this.invalidate();
+    if (this.source.size !== sizeBefore) {
+      this.invalidate();
+    }
   }
 
   exists(item: T): boolean {
@@ -40,8 +43,10 @@ export class InternalSetList<T> implements IInternalList<T> {
   }
 
   remove(item: T): void {
-    this.source.delete(item);
-    this.invalidate();
+    const didDelete = this.source.delete(item);
+    if (didDelete) {
+      this.invalidate();
+    }
   }
 
   update(newItem: T, oldItem: T): void {

--- a/test/IndexBasePerformance.test.ts
+++ b/test/IndexBasePerformance.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { getByMakeIndex } from './shared/indexes';
+import { newTeslaModel3 } from './shared/data';
+
+// Tests for internal map growth during read/unIndex operations
+
+describe('IndexBase performance behaviors', () => {
+  it('getValue on empty index should not create new maps', () => {
+    const index = getByMakeIndex();
+    index.getValue('Tesla');
+    expect(index.internalMap.size).toBe(0);
+  });
+
+  it('unIndex on empty index should not create new maps', () => {
+    const index = getByMakeIndex();
+    index.unIndex(newTeslaModel3);
+    expect(index.internalMap.size).toBe(0);
+  });
+});

--- a/test/internals/InternalSetList.test.ts
+++ b/test/internals/InternalSetList.test.ts
@@ -30,6 +30,22 @@ describe('invalidation test', () => {
       });
     });
 
+    describe('add existing element', () => {
+      let sameOutput: readonly number[];
+      beforeEach(() => {
+        sameOutput = list.output;
+        list.add(6);
+      });
+
+      test('source size remains the same', () => {
+        expect(list.source.size).toBe(3);
+      });
+
+      test('output instance should remain the same', () => {
+        expect(list.output).toBe(sameOutput);
+      });
+    });
+
     describe('remove', () => {
       beforeEach(() => {
         list.remove(6);
@@ -45,6 +61,22 @@ describe('invalidation test', () => {
 
       test('output should return a different instance of array', () => {
         expect(list.output).not.toBe(outputBefore);
+      });
+    });
+
+    describe('remove non-existing element', () => {
+      let sameOutput: readonly number[];
+      beforeEach(() => {
+        sameOutput = list.output;
+        list.remove(100);
+      });
+
+      test('source should remain unchanged', () => {
+        expect(list.source.size).toBe(3);
+      });
+
+      test('output instance should remain the same', () => {
+        expect(list.output).toBe(sameOutput);
       });
     });
   });


### PR DESCRIPTION
## Summary
- avoid unneeded invalidation when InternalSetList add/remove does nothing
- prevent IndexBase lookups from mutating tree
- guard removeItemFromMap when key missing
- test InternalSetList no-op operations
- test IndexBase read/unIndex do not mutate maps

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_b_68703dc876a4832b8b8974286b305ee8