### PR TITLE
refactor: Rename methods and improve InternalSetList performance

### DIFF
--- a/src/collections/IndexedCollectionBase.ts
+++ b/src/collections/IndexedCollectionBase.ts
@@ -126,7 +126,7 @@ export abstract class IndexedCollectionBase<T> extends SignalObserver implements
     this._allItemList.remove(item);
 
     for (const index of this.indexes) {
-      index.unIndex(item);
+      index.removeFromIndex(item);
     }
     this.notifyChange({
       removed: [item],
@@ -140,7 +140,7 @@ export abstract class IndexedCollectionBase<T> extends SignalObserver implements
     }
 
     for (const index of this.indexes) {
-      index.unIndex(oldItem);
+      index.removeFromIndex(oldItem);
     }
 
     this._allItemList.update(newItem, oldItem);

--- a/src/core/IIndex.ts
+++ b/src/core/IIndex.ts
@@ -11,7 +11,7 @@ export interface IIndex<T> {
    * @param item
    * @return true if the item has been removed to the index successfully.
    */
-  unIndex(item: T): boolean;
+  removeFromIndex(item: T): boolean;
 
   reset(): void;
 }

--- a/src/core/internals/InternalSetList.ts
+++ b/src/core/internals/InternalSetList.ts
@@ -44,8 +44,11 @@ export class InternalSetList<T> implements IInternalList<T> {
    * Add an item to the set.
    */
   add(item: T): void {
+    const sizeBefore = this.source.size;
     this.source.add(item);
-    this.invalidate();
+    if (this.source.size !== sizeBefore) {
+      this.invalidate();
+    }
   }
 
   /**
@@ -59,8 +62,10 @@ export class InternalSetList<T> implements IInternalList<T> {
    * Remove an item from the set.
    */
   remove(item: T): void {
-    this.source.delete(item);
-    this.invalidate();
+    const didDelete = this.source.delete(item);
+    if (didDelete) {
+      this.invalidate();
+    }
   }
 
   /**

--- a/test/internals/InternalList.test.ts
+++ b/test/internals/InternalList.test.ts
@@ -64,7 +64,6 @@ describe('invalidation test', () => {
       });
 
       test('source reorder the number according to the move', () => {
-        console.log(list.source);
         expect(list.source).toEqual([6, 1, 7]);
       });
     });

--- a/test/internals/InternalSetList.test.ts
+++ b/test/internals/InternalSetList.test.ts
@@ -30,6 +30,22 @@ describe('invalidation test', () => {
       });
     });
 
+    describe('add existing element', () => {
+      let sameOutput: readonly number[];
+      beforeEach(() => {
+        sameOutput = list.output;
+        list.add(6);
+      });
+
+      test('source size remains the same', () => {
+        expect(list.source.size).toBe(3);
+      });
+
+      test('output instance should remain the same', () => {
+        expect(list.output).toBe(sameOutput);
+      });
+    });
+
     describe('remove', () => {
       beforeEach(() => {
         list.remove(6);
@@ -45,6 +61,22 @@ describe('invalidation test', () => {
 
       test('output should return a different instance of array', () => {
         expect(list.output).not.toBe(outputBefore);
+      });
+    });
+
+    describe('remove non-existing element', () => {
+      let sameOutput: readonly number[];
+      beforeEach(() => {
+        sameOutput = list.output;
+        list.remove(100);
+      });
+
+      test('source should remain unchanged', () => {
+        expect(list.source.size).toBe(3);
+      });
+
+      test('output instance should remain the same', () => {
+        expect(list.output).toBe(sameOutput);
       });
     });
   });

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,7 @@
+import { configDefaults, defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    exclude: [...configDefaults.exclude, '.sl/*'],
+  },
+})


### PR DESCRIPTION
This PR refactors method names and optimizes internal list handling by reducing unnecessary invalidations and clarifies index mutation behavior.

- Renames `unIndex` to `removeFromIndex` across interface, base class, and callers  
- Optimizes `InternalSetList` to only call `invalidate` when an actual change occurs  
- Updates `IndexBase.getLeafMaps` to explicitly control leaf-map creation via a `createIfMissing` flag
